### PR TITLE
Update makefile to produce AMD64 Binaries for windows / linux

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,9 +35,11 @@ build: .pre-build
 	GOOS=darwin GOARCH=amd64 go build -o build/darwin/${APP_NAME}.amd64.ext
 	GOOS=darwin GOARCH=arm64 go build -o build/darwin/${APP_NAME}.arm64.ext
 	/usr/bin/lipo -create -output build/darwin/${APP_NAME}.ext build/darwin/${APP_NAME}.amd64.ext build/darwin/${APP_NAME}.arm64.ext
-	@sudo codesign --timestamp --force --deep -s "${DEV_APP_CERT}" build/darwin/${APP_NAME}.ext
-	GOOS=linux go build -o build/linux/${APP_NAME}.ext
-	GOOS=windows go build -o build/windows/${APP_NAME}.ext.exe
+	# @sudo codesign --timestamp --force --deep -s "${DEV_APP_CERT}" build/darwin/${APP_NAME}.ext
+	GOOS=linux GOARCH=amd64  go build -o build/linux/${APP_NAME}.amd64.ext
+	GOOS=linux GOARCH=arm64  go build -o build/linux/${APP_NAME}.arm64.ext
+	GOOS=windows GOARCH=amd64  go build -o build/windows/${APP_NAME}.amd64.ext.exe
+	GOOS=windows GOARCH=arm64  go build -o build/windows/${APP_NAME}.arm64.ext
 	/bin/rm build/darwin/${APP_NAME}.amd64.ext
 	/bin/rm build/darwin/${APP_NAME}.arm64.ext
 

--- a/Makefile
+++ b/Makefile
@@ -39,7 +39,7 @@ build: .pre-build
 	GOOS=linux GOARCH=amd64  go build -o build/linux/${APP_NAME}.amd64.ext
 	GOOS=linux GOARCH=arm64  go build -o build/linux/${APP_NAME}.arm64.ext
 	GOOS=windows GOARCH=amd64  go build -o build/windows/${APP_NAME}.amd64.ext.exe
-	GOOS=windows GOARCH=arm64  go build -o build/windows/${APP_NAME}.arm64.ext
+	GOOS=windows GOARCH=arm64  go build -o build/windows/${APP_NAME}.arm64.ext.exe
 	/bin/rm build/darwin/${APP_NAME}.amd64.ext
 	/bin/rm build/darwin/${APP_NAME}.arm64.ext
 

--- a/Makefile
+++ b/Makefile
@@ -35,7 +35,7 @@ build: .pre-build
 	GOOS=darwin GOARCH=amd64 go build -o build/darwin/${APP_NAME}.amd64.ext
 	GOOS=darwin GOARCH=arm64 go build -o build/darwin/${APP_NAME}.arm64.ext
 	/usr/bin/lipo -create -output build/darwin/${APP_NAME}.ext build/darwin/${APP_NAME}.amd64.ext build/darwin/${APP_NAME}.arm64.ext
-	# @sudo codesign --timestamp --force --deep -s "${DEV_APP_CERT}" build/darwin/${APP_NAME}.ext
+	@sudo codesign --timestamp --force --deep -s "${DEV_APP_CERT}" build/darwin/${APP_NAME}.ext
 	GOOS=linux GOARCH=amd64  go build -o build/linux/${APP_NAME}.amd64.ext
 	GOOS=linux GOARCH=arm64  go build -o build/linux/${APP_NAME}.arm64.ext
 	GOOS=windows GOARCH=amd64  go build -o build/windows/${APP_NAME}.amd64.ext.exe


### PR DESCRIPTION
Currently the `GOARCH` is not specified as such when a build is run on an Apple silicon device the Arch is defauled to arm64 resulting in the uploaded packages being built for Arm. 

This is true of release 0.0.7 & 0.0.6 for example

```
file ./linux/macadmins_extension.ext

./linux/macadmins_extension.ext: ELF 64-bit LSB executable, ARM aarch64, version 1 (SYSV), statically linked, Go BuildID=4TvGeSUpeSaDe8Zs--7Y/VDQoTE7-WnYHHJNrBtbs/NlJ7g_Pxs6zbFiIsBcqs/pc7E2In48j3Dwp1HaxKe, not stripped
```

```
file ./windows/macadmins_extension.ext.exe
./windows/macadmins_extension.ext.exe: PE32+ executable (console) Aarch64 (stripped to external PDB), for MS Windows
```

As Lipo does not work to make universal go binaries for windows / linux include both as files in the zip.
