### PR TITLE
Add `display_name` column to `munki_installs`

### DIFF
--- a/tables/chromeuserprofiles/chrome_user_profiles.go
+++ b/tables/chromeuserprofiles/chrome_user_profiles.go
@@ -3,7 +3,6 @@ package chromeuserprofiles
 import (
 	"context"
 	"encoding/json"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -68,7 +67,7 @@ func GoogleChromeProfilesColumns() []table.ColumnDefinition {
 
 func generateForPath(ctx context.Context, fileInfo userFileInfo) ([]map[string]string, error) {
 	var results []map[string]string
-	data, err := ioutil.ReadFile(fileInfo.path)
+	data, err := os.ReadFile(fileInfo.path)
 	if err != nil {
 		return nil, errors.Wrap(err, "reading chrome local state file")
 	}
@@ -130,7 +129,7 @@ func findFileInUserDirs(pattern string, opts ...FindFileOpt) ([]userFileInfo, er
 	if ff.username == "" {
 		for _, possibleHome := range homedirRoots {
 
-			userDirs, err := ioutil.ReadDir(possibleHome)
+			userDirs, err := os.ReadDir(possibleHome)
 			if err != nil {
 				// This possibleHome doesn't exist. Move on
 				continue

--- a/tables/mdm/mdm.go
+++ b/tables/mdm/mdm.go
@@ -3,7 +3,7 @@ package mdm
 import (
 	"bytes"
 	"context"
-	"io/ioutil"
+	"io"
 	"os"
 	"os/exec"
 	"strconv"
@@ -215,7 +215,7 @@ func hasCheckedCloudConfigInPast24Hours() bool {
 		return false
 	}
 
-	byteValue, err := ioutil.ReadAll(plistFile)
+	byteValue, err := io.ReadAll(plistFile)
 	if err != nil {
 		// could not read file to bytes
 		return false
@@ -245,7 +245,7 @@ func getCachedDEPStatus() bool {
 		return false
 	}
 
-	byteValue, err := ioutil.ReadAll(plistFile)
+	byteValue, err := io.ReadAll(plistFile)
 	if err != nil {
 		// could not read file to bytes
 		return false

--- a/tables/munki/munki.go
+++ b/tables/munki/munki.go
@@ -30,6 +30,7 @@ type managedInstall struct {
 	Installed        bool   `plist:"installed"`
 	InstalledVersion string `plist:"installed_version"`
 	Name             string `plist:"name"`
+	DisplayName      string `plist:"display_name"`
 }
 
 func MunkiInfoColumns() []table.ColumnDefinition {
@@ -83,6 +84,7 @@ func MunkiInstallsColumns() []table.ColumnDefinition {
 		table.TextColumn("installed"),
 		table.TextColumn("name"),
 		table.TextColumn("end_time"),
+		table.TextColumn("display_name"),
 	}
 }
 
@@ -102,6 +104,7 @@ func MunkiInstallsGenerate(ctx context.Context, queryContext table.QueryContext)
 			"installed":         fmt.Sprintf("%v", install.Installed),
 			"name":              install.Name,
 			"end_time":          report.EndTime,
+			"display_name":      install.DisplayName,
 		})
 	}
 
@@ -109,9 +112,11 @@ func MunkiInstallsGenerate(ctx context.Context, queryContext table.QueryContext)
 
 }
 
+// reportPath is defined as a global variable to ease testing.
+var reportPath = "/Library/Managed Installs/ManagedInstallReport.plist"
+
 func loadMunkiReport() (*munkiReport, error) {
 	var report munkiReport
-	const reportPath = "/Library/Managed Installs/ManagedInstallReport.plist"
 	if !utils.FileExists(reportPath) {
 		return nil, nil
 	}

--- a/tables/munki/munki_test.go
+++ b/tables/munki/munki_test.go
@@ -1,0 +1,46 @@
+package munki
+
+import (
+	"context"
+	_ "embed"
+	"os"
+	"path/filepath"
+	"reflect"
+	"testing"
+
+	"github.com/osquery/osquery-go/plugin/table"
+)
+
+//go:embed test_ManagedInstallReport.plist
+var testManagedInstallReport []byte
+
+func TestMunkiInstallsGenerate(t *testing.T) {
+	reportPath = filepath.Join(t.TempDir(), "ManagedInstallReport.plist")
+	err := os.WriteFile(reportPath, testManagedInstallReport, 0600)
+	if err != nil {
+		t.Fatal(err)
+	}
+	rows, err := MunkiInstallsGenerate(context.Background(), table.QueryContext{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	expectedRows := []map[string]string{
+		{
+			"installed_version": "105.0.5195.125",
+			"installed":         "true",
+			"name":              "Google Chrome",
+			"end_time":          "2022-09-22 11:53:01 +0000",
+			"display_name":      "Google Chrome Display Name",
+		},
+		{
+			"installed_version": "1.1.7.81411",
+			"installed":         "false",
+			"name":              "Nudge",
+			"end_time":          "2022-09-22 11:53:01 +0000",
+			"display_name":      "Nudge Display Name",
+		},
+	}
+	if !reflect.DeepEqual(rows, expectedRows) {
+		t.Fatalf("rows mismatch: %+v vs. %+v", rows, expectedRows)
+	}
+}

--- a/tables/munki/test_ManagedInstallReport.plist
+++ b/tables/munki/test_ManagedInstallReport.plist
@@ -1,0 +1,149 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>AvailableDiskSpace</key>
+	<integer>371095948</integer>
+	<key>Conditions</key>
+	<dict>
+		<key>arch</key>
+		<string>x86_64</string>
+		<key>date</key>
+		<date>2022-09-22T08:52:43Z</date>
+		<key>hostname</key>
+		<string>Foo-MacBook-Pro.local</string>
+		<key>ibridge_model_name</key>
+		<string>Apple T2 Security Chip</string>
+		<key>ipv4_address</key>
+		<array>
+			<string>192.168.0.230</string>
+		</array>
+		<key>ipv6_address</key>
+		<array/>
+		<key>machine_model</key>
+		<string>MacBookPro16,2</string>
+		<key>machine_type</key>
+		<string>laptop</string>
+		<key>munki_version</key>
+		<string>5.6.4.4406</string>
+		<key>os_build_last_component</key>
+		<integer>115</integer>
+		<key>os_build_number</key>
+		<string>21G115</string>
+		<key>os_vers</key>
+		<string>12.6</string>
+		<key>os_vers_major</key>
+		<integer>12</integer>
+		<key>os_vers_minor</key>
+		<integer>6</integer>
+		<key>os_vers_patch</key>
+		<integer>0</integer>
+		<key>serial_number</key>
+		<string>Foo</string>
+		<key>x86_64_capable</key>
+		<true/>
+	</dict>
+	<key>ConsoleUser</key>
+	<string>Foo</string>
+	<key>EndTime</key>
+	<string>2022-09-22 11:53:01 +0000</string>
+	<key>Errors</key>
+	<array/>
+	<key>InstallResults</key>
+	<array/>
+	<key>InstalledItems</key>
+	<array>
+		<string>Google Chrome</string>
+		<string>Nudge</string>
+	</array>
+	<key>ItemsToInstall</key>
+	<array/>
+	<key>ItemsToRemove</key>
+	<array/>
+	<key>MachineInfo</key>
+	<dict>
+		<key>arch</key>
+		<string>x86_64</string>
+		<key>hostname</key>
+		<string>Foo-MacBook-Pro.local</string>
+		<key>ibridge_model_name</key>
+		<string>Apple T2 Security Chip</string>
+		<key>ipv4_address</key>
+		<array>
+			<string>192.168.0.230</string>
+		</array>
+		<key>ipv6_address</key>
+		<array/>
+		<key>machine_model</key>
+		<string>MacBookPro16,2</string>
+		<key>munki_version</key>
+		<string>5.6.4.4406</string>
+		<key>os_build_number</key>
+		<string>21G115</string>
+		<key>os_vers</key>
+		<string>12.6</string>
+		<key>serial_number</key>
+		<string>Foo</string>
+		<key>x86_64_capable</key>
+		<true/>
+	</dict>
+	<key>ManagedInstallVersion</key>
+	<string>5.6.4.4406</string>
+	<key>ManagedInstalls</key>
+	<array>
+		<dict>
+			<key>description</key>
+			<string>Chrome is a fast, simple, and secure web browser, built for the modern web.</string>
+			<key>display_name</key>
+			<string>Google Chrome Display Name</string>
+			<key>installed</key>
+			<true/>
+			<key>installed_size</key>
+			<integer>473937</integer>
+			<key>installed_version</key>
+			<string>105.0.5195.125</string>
+			<key>name</key>
+			<string>Google Chrome</string>
+		</dict>
+		<dict>
+			<key>description</key>
+			<string></string>
+			<key>display_name</key>
+			<string>Nudge Display Name</string>
+			<key>installed</key>
+			<false/>
+			<key>installed_size</key>
+			<integer>6566</integer>
+			<key>installed_version</key>
+			<string>1.1.7.81411</string>
+			<key>name</key>
+			<string>Nudge</string>
+		</dict>
+	</array>
+	<key>ManifestName</key>
+	<string>e388bb34-ea80-49e2-8d79-da164f8bf9af</string>
+	<key>ProblemInstalls</key>
+	<array/>
+	<key>RemovalResults</key>
+	<array/>
+	<key>RemovedItems</key>
+	<array/>
+	<key>RunType</key>
+	<string>auto</string>
+	<key>StartTime</key>
+	<string>2022-09-22 11:52:43 +0000</string>
+	<key>Warnings</key>
+	<array>
+		<string>Could not process item Foo for optional install. No pkginfo found in catalogs: default</string>
+	</array>
+	<key>managed_installs_list</key>
+	<array>
+		<string>Google Chrome</string>
+		<string>Nudge</string>
+	</array>
+	<key>managed_uninstalls_list</key>
+	<array/>
+	<key>managed_updates_list</key>
+	<array/>
+</dict>
+</plist>


### PR DESCRIPTION
This PR adds the `display_name` property to `munki_installs`. And adds a simple unit test.

Why?

Solutions like SimpleMDM that integrate with Munki use random identifiers in the `name` field, so it's hard to identify the apps when querying `select * from munki_installs`.
