### PR TITLE
Add sofa url column

### DIFF
--- a/tables/sofa/sofa_cves.go
+++ b/tables/sofa/sofa_cves.go
@@ -22,6 +22,7 @@ func SofaUnpatchedCVEsColumns() []table.ColumnDefinition {
 		table.TextColumn("cve"),
 		table.TextColumn("patched_version"),
 		table.TextColumn("actively_exploited"),
+		table.TextColumn("url"),
 	}
 }
 
@@ -85,6 +86,7 @@ func SofaUnpatchedCVEsGenerate(ctx context.Context, queryContext table.QueryCont
 			"cve":                unpatchedCVE.CVE,
 			"patched_version":    unpatchedCVE.PatchedVersion,
 			"actively_exploited": strconv.FormatBool(unpatchedCVE.ActivelyExploited),
+			"url":                url,
 		})
 	}
 

--- a/tables/sofa/sofa_info.go
+++ b/tables/sofa/sofa_info.go
@@ -127,6 +127,7 @@ func SofaSecurityReleaseInfoColumns() []table.ColumnDefinition {
 		table.IntegerColumn("unique_cves_count"),
 		table.IntegerColumn("days_since_previous_release"),
 		table.TextColumn("os_version"),
+		table.TextColumn("url"),
 	}
 }
 
@@ -163,10 +164,10 @@ func SofaSecurityReleaseInfoGenerate(ctx context.Context, queryContext table.Que
 		return nil, err
 	}
 
-	return buildSecurityReleaseInfoOutput(securityReleases, osVersion), nil
+	return buildSecurityReleaseInfoOutput(securityReleases, osVersion, url), nil
 }
 
-func buildSecurityReleaseInfoOutput(securityReleases []SecurityRelease, osVersion string) []map[string]string {
+func buildSecurityReleaseInfoOutput(securityReleases []SecurityRelease, osVersion, url string) []map[string]string {
 	var results []map[string]string
 	for _, securityRelease := range securityReleases {
 		results = append(results, map[string]string{
@@ -177,6 +178,7 @@ func buildSecurityReleaseInfoOutput(securityReleases []SecurityRelease, osVersio
 			"unique_cves_count":           strconv.Itoa(securityRelease.UniqueCVEsCount),
 			"days_since_previous_release": strconv.Itoa(securityRelease.DaysSincePreviousRelease),
 			"os_version":                  osVersion,
+			"url":                         url,
 		})
 	}
 	return results

--- a/tables/sofa/sofa_info_test.go
+++ b/tables/sofa/sofa_info_test.go
@@ -158,10 +158,11 @@ func TestBuildSecurityReleaseInfoOutput(t *testing.T) {
 			"unique_cves_count":           "3",
 			"days_since_previous_release": "30",
 			"os_version":                  "14.5.1",
+			"url":                         SofaV1URL,
 		},
 	}
 
-	output := buildSecurityReleaseInfoOutput(securityReleases, osVersion)
+	output := buildSecurityReleaseInfoOutput(securityReleases, osVersion, SofaV1URL)
 
 	assert.Equal(t, expectedOutput, output)
 }


### PR DESCRIPTION
When attempting to use the `url` filter on `sofa_security_release_info` and `sofa_unpatched_cves` tables the following error is occuring:

```
osquery> select * from sofa_security_release_info WHERE url = 'foo';
Error: no such column: url
```

This change adds `url` columns to both tables.  To note, this was not tested with an alternative sofa feed.