### PR TITLE
feat: add date parsing support for munki 7

### DIFF
--- a/tables/munki/munki_test.go
+++ b/tables/munki/munki_test.go
@@ -14,6 +14,9 @@ import (
 //go:embed test_ManagedInstallReport.plist
 var testManagedInstallReport []byte
 
+//go:embed test_ManagedInstallReport_munki7.plist
+var testManagedInstallReportMunki7 []byte
+
 func TestMunkiInstallsGenerate(t *testing.T) {
 	reportPath = filepath.Join(t.TempDir(), "ManagedInstallReport.plist")
 	err := os.WriteFile(reportPath, testManagedInstallReport, 0600)
@@ -43,4 +46,54 @@ func TestMunkiInstallsGenerate(t *testing.T) {
 
 	assert.Equal(t, rows, expectedRows, "Output rows are not equal")
 
+}
+
+func TestMunkiInstallsGenerateMunki7(t *testing.T) {
+	reportPath = filepath.Join(t.TempDir(), "ManagedInstallReport.plist")
+	err := os.WriteFile(reportPath, testManagedInstallReportMunki7, 0600)
+	if err != nil {
+		t.Fatal(err)
+	}
+	rows, err := MunkiInstallsGenerate(context.Background(), table.QueryContext{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	expectedRows := []map[string]string{
+		{
+			"installed_version": "128.0.6613.113",
+			"installed":         "true",
+			"name":              "Google Chrome",
+			"end_time":          "2025-07-28 20:09:58 +0000",
+			"display_name":      "Google Chrome",
+		},
+	}
+
+	assert.Equal(t, rows, expectedRows, "Munki 7 output rows are not equal")
+}
+
+func TestMunkiInfoGenerateMunki7(t *testing.T) {
+	reportPath = filepath.Join(t.TempDir(), "ManagedInstallReport.plist")
+	err := os.WriteFile(reportPath, testManagedInstallReportMunki7, 0600)
+	if err != nil {
+		t.Fatal(err)
+	}
+	rows, err := MunkiInfoGenerate(context.Background(), table.QueryContext{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	expectedRows := []map[string]string{
+		{
+			"start_time":       "2025-07-28 20:08:30 +0000",
+			"end_time":         "2025-07-28 20:09:58 +0000",
+			"console_user":     "TestUser",
+			"version":          "7.0.0",
+			"success":          "true",
+			"errors":           "",
+			"warnings":         "",
+			"problem_installs": "",
+			"manifest_name":    "test-manifest",
+		},
+	}
+
+	assert.Equal(t, rows, expectedRows, "Munki 7 info output rows are not equal")
 }

--- a/tables/munki/test_ManagedInstallReport_munki7.plist
+++ b/tables/munki/test_ManagedInstallReport_munki7.plist
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>AvailableDiskSpace</key>
+	<integer>371095948</integer>
+	<key>ConsoleUser</key>
+	<string>TestUser</string>
+	<key>EndTime</key>
+	<date>2025-07-28T20:09:58Z</date>
+	<key>Errors</key>
+	<array/>
+	<key>ManagedInstallVersion</key>
+	<string>7.0.0</string>
+	<key>ManagedInstalls</key>
+	<array>
+		<dict>
+			<key>description</key>
+			<string>Chrome is a fast, simple, and secure web browser, built for the modern web.</string>
+			<key>display_name</key>
+			<string>Google Chrome</string>
+			<key>installed</key>
+			<true/>
+			<key>installed_size</key>
+			<integer>473937</integer>
+			<key>installed_version</key>
+			<string>128.0.6613.113</string>
+			<key>name</key>
+			<string>Google Chrome</string>
+		</dict>
+	</array>
+	<key>ManifestName</key>
+	<string>test-manifest</string>
+	<key>ProblemInstalls</key>
+	<array/>
+	<key>StartTime</key>
+	<date>2025-07-28T20:08:30Z</date>
+	<key>Warnings</key>
+	<array/>
+</dict>
+</plist>


### PR DESCRIPTION
This PR introduces a new `MunkiDate` type to handle differences in how Munki stores dates in `ManagedInstallReport.plist` between versions:

- Munki 6 (and previous) stores dates as strings in the report plist.
- Munki 7 stores dates as native plist date objects.

`MunkiDate` implements a custom `UnmarshalPlist` method that supports both formats, ensuring compatibility across Munki versions.

e.g.:
### Munki 6
```
<key>StartTime</key>
<string>2025-07-28 20:27:49 +0000</string>
```

### Munki 7
```
<key>StartTime</key>
<date>2025-07-28T20:09:58Z</date>
```

### osquery output
```
osquery> select * from munki_info;
+------------+---------------------------+---------------------------+---------+--------+----------+--------------+------------------+---------------+
| version    | start_time                | end_time                  | success | errors | warnings | console_user | problem_installs | manifest_name |
+------------+---------------------------+---------------------------+---------+--------+----------+--------------+------------------+---------------+
| 6.6.0.4686 | 2025-10-06 20:06:31 +0000 | 2025-10-06 20:06:43 +0000 | true    |        |          | haircut      |                  | site_default  |
+------------+---------------------------+---------------------------+---------+--------+----------+--------------+------------------+---------------+
osquery> select * from munki_info;
+------------+---------------------------+---------------------------+---------+--------+----------+--------------+------------------+---------------+
| version    | start_time                | end_time                  | success | errors | warnings | console_user | problem_installs | manifest_name |
+------------+---------------------------+---------------------------+---------+--------+----------+--------------+------------------+---------------+
| 7.0.0.5328 | 2025-10-07 01:11:51 +0000 | 2025-10-07 01:11:55 +0000 | true    |        |          | haircut      |                  | site_default  |
+------------+---------------------------+---------------------------+---------+--------+----------+--------------+------------------+---------------+
```

This implementation is backward-compatible and does not change table schema or output format; it only improves date parsing reliability.

This fixes #67.
