### PR TITLE
Upgrade golangci-lint action to version 4

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -12,4 +12,6 @@ jobs:
           go-version: ${{ env.GO_VERSION }}
       - uses: actions/checkout@v2
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v2
+        uses: golangci/golangci-lint-action@v4
+        with:
+          version: latest


### PR DESCRIPTION
Updated golangci-lint action to version 4 and set version to latest.