### PR TITLE
[codex] Improve filevaultusers table tests

### DIFF
--- a/tables/filevaultusers/BUILD.bazel
+++ b/tables/filevaultusers/BUILD.bazel
@@ -15,5 +15,8 @@ go_test(
     name = "filevaultusers_test",
     srcs = ["filevaultusers_test.go"],
     embed = [":filevaultusers"],
-    deps = ["@com_github_stretchr_testify//assert"],
+    deps = [
+        "@com_github_stretchr_testify//assert",
+        "@com_github_stretchr_testify//require",
+    ],
 )

--- a/tables/filevaultusers/filevaultusers.go
+++ b/tables/filevaultusers/filevaultusers.go
@@ -62,7 +62,9 @@ func getFileVaultUsers() ([]FileVaultUser, error) {
 
 }
 
-func runFDESetupList() ([]byte, error) {
+var runFDESetupList = runFDESetupListCommand
+
+func runFDESetupListCommand() ([]byte, error) {
 	var out []byte
 	out, err := exec.Command("/usr/bin/fdesetup", "list").Output()
 

--- a/tables/filevaultusers/filevaultusers_test.go
+++ b/tables/filevaultusers/filevaultusers_test.go
@@ -1,10 +1,30 @@
 package filevaultusers
 
 import (
+	"context"
+	"errors"
 	"testing"
 
+	"github.com/osquery/osquery-go/plugin/table"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
+
+func withRunFDESetupList(t *testing.T, fn func() ([]byte, error)) {
+	t.Helper()
+	original := runFDESetupList
+	runFDESetupList = fn
+	t.Cleanup(func() {
+		runFDESetupList = original
+	})
+}
+
+func TestFileVaultUsersColumns(t *testing.T) {
+	assert.Equal(t, []table.ColumnDefinition{
+		table.TextColumn("username"),
+		table.TextColumn("uuid"),
+	}, FileVaultUsersColumns())
+}
 
 func TestProcessFDESetupToUsers(t *testing.T) {
 	t.Parallel()
@@ -47,4 +67,79 @@ func TestProcessFDESetupToUsersWithMultilineInput(t *testing.T) {
 
 	assert.Equal(t, expectedOutput, output, "Expected output does not match real output")
 
+}
+
+func TestProcessFDESetupToUsersIgnoresBlankLines(t *testing.T) {
+	t.Parallel()
+	inputBytes := []byte("\ngraham,163DDC62-5D23-40A2-8EC9-0190B267251B\n\n")
+	output, err := processFDESetupToUsers(inputBytes)
+	require.NoError(t, err)
+	assert.Equal(t, []FileVaultUser{
+		{Username: "graham", UUID: "163DDC62-5D23-40A2-8EC9-0190B267251B"},
+	}, output)
+}
+
+func TestProcessFDESetupToUsersEmptyInput(t *testing.T) {
+	t.Parallel()
+	output, err := processFDESetupToUsers(nil)
+	require.NoError(t, err)
+	assert.Empty(t, output)
+}
+
+func TestGetFileVaultUsers(t *testing.T) {
+	withRunFDESetupList(t, func() ([]byte, error) {
+		return []byte("graham,163DDC62-5D23-40A2-8EC9-0190B267251B"), nil
+	})
+
+	output, err := getFileVaultUsers()
+	require.NoError(t, err)
+	assert.Equal(t, []FileVaultUser{
+		{Username: "graham", UUID: "163DDC62-5D23-40A2-8EC9-0190B267251B"},
+	}, output)
+}
+
+func TestGetFileVaultUsersCommandError(t *testing.T) {
+	withRunFDESetupList(t, func() ([]byte, error) {
+		return nil, errors.New("fdesetup failed")
+	})
+
+	output, err := getFileVaultUsers()
+	assert.Error(t, err)
+	assert.Empty(t, output)
+	assert.ErrorContains(t, err, "runFDESetupList")
+	assert.ErrorContains(t, err, "fdesetup failed")
+}
+
+func TestGetFileVaultUsersParseError(t *testing.T) {
+	withRunFDESetupList(t, func() ([]byte, error) {
+		return []byte("graham,uuid,extra"), nil
+	})
+
+	output, err := getFileVaultUsers()
+	assert.Error(t, err)
+	assert.Empty(t, output)
+	assert.ErrorContains(t, err, "processFDESetupToUsers")
+}
+
+func TestFileVaultUsersGenerate(t *testing.T) {
+	withRunFDESetupList(t, func() ([]byte, error) {
+		return []byte("graham,163DDC62-5D23-40A2-8EC9-0190B267251B\ndave,A643042D-6F7C-4A87-9EDB-2CA267035B01"), nil
+	})
+
+	results, err := FileVaultUsersGenerate(context.Background(), table.QueryContext{})
+	require.NoError(t, err)
+	assert.Equal(t, []map[string]string{
+		{"username": "graham", "uuid": "163DDC62-5D23-40A2-8EC9-0190B267251B"},
+		{"username": "dave", "uuid": "A643042D-6F7C-4A87-9EDB-2CA267035B01"},
+	}, results)
+}
+
+func TestFileVaultUsersGenerateError(t *testing.T) {
+	withRunFDESetupList(t, func() ([]byte, error) {
+		return nil, errors.New("fdesetup failed")
+	})
+
+	results, err := FileVaultUsersGenerate(context.Background(), table.QueryContext{})
+	assert.Error(t, err)
+	assert.Empty(t, results)
 }


### PR DESCRIPTION
## Summary
- add FileVault column and generator coverage
- make fdesetup execution injectable for deterministic tests
- cover command errors, parse errors, blank lines, and empty input

## Validation
- GOCACHE=/tmp/osquery-extension-go-cache go test ./tables/filevaultusers
- GOCACHE=/tmp/osquery-extension-go-cache go test ./...