### PR TITLE
[codex] Improve unifiedlog table tests

### DIFF
--- a/tables/unifiedlog/unified_log.go
+++ b/tables/unifiedlog/unified_log.go
@@ -71,6 +71,11 @@ func UnifiedLogColumns() []table.ColumnDefinition {
 }
 
 func UnifiedLogGenerate(ctx context.Context, queryContext table.QueryContext) ([]map[string]string, error) {
+	r := utils.NewRunner()
+	return generateWithRunner(queryContext, r)
+}
+
+func generateWithRunner(queryContext table.QueryContext, r utils.Runner) ([]map[string]string, error) {
 	predicate := ""
 	last := ""
 	logLevel := ""
@@ -109,8 +114,6 @@ func UnifiedLogGenerate(ctx context.Context, queryContext table.QueryContext) ([
 	if predicate == "" && last == "" {
 		return []map[string]string{}, nil
 	}
-
-	r := utils.NewRunner()
 
 	output, err := execute(predicate, last, logLevel, r)
 	if err != nil {
@@ -176,7 +179,7 @@ func execute(predicate string, last string, logLevel string, r utils.Runner) ([]
 			"process_id":                 strconv.Itoa(item.ProcessID),
 			"sender_program_counter":     strconv.Itoa(item.SenderProgramCounter),
 			"parent_activity_identifier": strconv.Itoa(item.ParentActivityIdentifier),
-			"timezone_name":              item.TimezoneName,
+			"time_zone_name":             item.TimezoneName,
 			"predicate":                  predicate,
 			"last":                       last,
 			"log_level":                  logLevel,

--- a/tables/unifiedlog/unified_log_test.go
+++ b/tables/unifiedlog/unified_log_test.go
@@ -1,11 +1,21 @@
 package unifiedlog
 
 import (
+	"context"
 	"testing"
 
 	"github.com/macadmins/osquery-extension/pkg/utils"
+	"github.com/osquery/osquery-go/plugin/table"
 	"github.com/stretchr/testify/assert"
 )
+
+func TestUnifiedLogColumns(t *testing.T) {
+	columns := UnifiedLogColumns()
+	assert.Contains(t, columns, table.TextColumn("time_zone_name"))
+	assert.Contains(t, columns, table.TextColumn("predicate"))
+	assert.Contains(t, columns, table.TextColumn("last"))
+	assert.Contains(t, columns, table.TextColumn("log_level"))
+}
 
 func TestExecute(t *testing.T) {
 	tests := []struct {
@@ -82,6 +92,15 @@ func TestExecute(t *testing.T) {
 			},
 			wantErr: true,
 		},
+		{
+			name:      "JSON error",
+			predicate: "eventMessage contains 'test'",
+			mockCmd: utils.MockCmdRunner{
+				Output: "not json",
+				Err:    nil,
+			},
+			wantErr: true,
+		},
 	}
 
 	for _, tt := range tests {
@@ -96,4 +115,88 @@ func TestExecute(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestExecuteBuildsCompleteRows(t *testing.T) {
+	runner := utils.Runner{Runner: utils.MockCmdRunner{
+		Output: `[{
+			"traceID": 42,
+			"eventType": "logEvent",
+			"formatString": "format",
+			"activityIdentifier": 7,
+			"subsystem": "com.example",
+			"category": "default",
+			"threadID": 123,
+			"senderImageUUID": "sender-uuid",
+			"bootUUID": "boot-uuid",
+			"processImagePath": "/usr/bin/example",
+			"timestamp": "2026-01-01 00:00:00.000000-0800",
+			"senderImagePath": "/usr/lib/libexample.dylib",
+			"creatorActivityID": 99,
+			"machTimestamp": 1000,
+			"eventMessage": "test message",
+			"processImageUUID": "process-uuid",
+			"processID": 456,
+			"senderProgramCounter": 789,
+			"parentActivityIdentifier": 6,
+			"timezoneName": "America/Los_Angeles"
+		}]`,
+	}}
+
+	output, err := execute("eventMessage contains 'test'", "1h", "debug", runner)
+	assert.NoError(t, err)
+	assert.Equal(t, []map[string]string{{
+		"trace_id":                   "42",
+		"event_type":                 "logEvent",
+		"format_string":              "format",
+		"activity_identifier":        "7",
+		"subsystem":                  "com.example",
+		"category":                   "default",
+		"thread_id":                  "123",
+		"sender_image_uuid":          "sender-uuid",
+		"boot_uuid":                  "boot-uuid",
+		"process_image_path":         "/usr/bin/example",
+		"timestamp":                  "2026-01-01 00:00:00.000000-0800",
+		"sender_image_path":          "/usr/lib/libexample.dylib",
+		"creator_activity_id":        "99",
+		"mach_timestamp":             "1000",
+		"event_message":              "test message",
+		"process_image_uuid":         "process-uuid",
+		"process_id":                 "456",
+		"sender_program_counter":     "789",
+		"parent_activity_identifier": "6",
+		"time_zone_name":             "America/Los_Angeles",
+		"predicate":                  "eventMessage contains 'test'",
+		"last":                       "1h",
+		"log_level":                  "debug",
+	}}, output)
+}
+
+func TestUnifiedLogGenerateWithoutPredicateOrLastReturnsEmpty(t *testing.T) {
+	output, err := UnifiedLogGenerate(context.Background(), table.QueryContext{})
+	assert.NoError(t, err)
+	assert.Empty(t, output)
+}
+
+func TestGenerateWithRunnerUsesConstraints(t *testing.T) {
+	output, err := generateWithRunner(table.QueryContext{
+		Constraints: map[string]table.ConstraintList{
+			"predicate": {Constraints: []table.Constraint{{
+				Operator:   table.OperatorEquals,
+				Expression: "eventMessage contains 'test'",
+			}}},
+			"last": {Constraints: []table.Constraint{{
+				Operator:   table.OperatorEquals,
+				Expression: "1h",
+			}}},
+			"log_level": {Constraints: []table.Constraint{{
+				Operator:   table.OperatorEquals,
+				Expression: "info",
+			}}},
+		},
+	}, utils.Runner{Runner: utils.MockCmdRunner{Output: `[{"eventMessage":"test message"}]`}})
+	assert.NoError(t, err)
+	assert.Equal(t, "eventMessage contains 'test'", output[0]["predicate"])
+	assert.Equal(t, "1h", output[0]["last"])
+	assert.Equal(t, "info", output[0]["log_level"])
 }


### PR DESCRIPTION
## Summary
- add unifiedlog column, generator guard, and constraint coverage
- verify full row mapping for log show JSON output
- cover JSON error handling
- fix time_zone_name output key to match the declared column

## Validation
- GOCACHE=/tmp/osquery-extension-go-cache go test ./tables/unifiedlog
- GOCACHE=/tmp/osquery-extension-go-cache go test ./...