### PR TITLE
[codex] Improve wifi_network table tests

### DIFF
--- a/tables/wifi_network/BUILD.bazel
+++ b/tables/wifi_network/BUILD.bazel
@@ -22,5 +22,6 @@ go_test(
         "//pkg/utils",
         "@com_github_osquery_osquery_go//plugin/table",
         "@com_github_stretchr_testify//assert",
+        "@com_github_stretchr_testify//require",
     ],
 )

--- a/tables/wifi_network/wifi_network.go
+++ b/tables/wifi_network/wifi_network.go
@@ -66,12 +66,16 @@ func WifiNetworkGenerate(
 	}
 	defer osqueryClient.Close()
 
-	wifiStatus, err := getWifiStatus(osqueryClient)
+	cmdExecutor := CmdExecutor{}
+	return generateWithDeps(osqueryClient, cmdExecutor)
+}
+
+func generateWithDeps(client utils.OsqueryClient, cmdExecutor CommandExecutor) ([]map[string]string, error) {
+	wifiStatus, err := getWifiStatus(client)
 	if err != nil {
 		return nil, err
 	}
 
-	cmdExecutor := CmdExecutor{}
 	wifiNetwork, err := buildWifiNetworkFromResponse(cmdExecutor, wifiStatus)
 	if err != nil {
 		return nil, err

--- a/tables/wifi_network/wifi_network_test.go
+++ b/tables/wifi_network/wifi_network_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/macadmins/osquery-extension/pkg/utils"
 	"github.com/osquery/osquery-go/plugin/table"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	_ "embed"
 )
@@ -14,25 +15,63 @@ import (
 //go:embed wdutil_out.txt
 var wdutilOut []byte
 
-type MockCommandExecutor struct{}
-
-func (m MockCommandExecutor) ExecCommand(name string, args ...string) ([]byte, error) {
-	if args[1] == "en0" {
-		return []byte("Current Wi-Fi Network: MyNetwork"), nil
-	}
-	// /usr/bin/wdutil info -q
-	if args[0] == "info" {
-		return wdutilOut, nil
-	}
-	return nil, errors.New("commad failed")
+type fakeCommandExecutor struct {
+	responses map[string][]byte
+	errors    map[string]error
+	calls     []commandCall
 }
 
-// TestExecCommand
-func TestExecCommand(t *testing.T) {
-	cmdExecutor := CmdExecutor{}
-	result, err := cmdExecutor.ExecCommand("echo", "hello")
-	assert.NoError(t, err)
-	assert.Equal(t, "hello\n", string(result))
+type commandCall struct {
+	name string
+	args []string
+}
+
+func (f *fakeCommandExecutor) ExecCommand(name string, args ...string) ([]byte, error) {
+	f.calls = append(f.calls, commandCall{name: name, args: args})
+	if err := f.errors[name]; err != nil {
+		return nil, err
+	}
+	if out, ok := f.responses[name]; ok {
+		return out, nil
+	}
+	return nil, errors.New("command failed")
+}
+
+func happyCommandExecutor() *fakeCommandExecutor {
+	return &fakeCommandExecutor{
+		responses: map[string][]byte{
+			"/usr/sbin/networksetup": []byte("Current Wi-Fi Network: MyNetwork\n"),
+			"/usr/bin/wdutil":        wdutilOut,
+		},
+		errors: map[string]error{},
+	}
+}
+
+type errorOsqueryClient struct {
+	err error
+}
+
+func (e errorOsqueryClient) QueryRows(query string) ([]map[string]string, error) {
+	return nil, e.err
+}
+
+func (e errorOsqueryClient) QueryRow(query string) (map[string]string, error) {
+	return nil, e.err
+}
+
+func (e errorOsqueryClient) Close() {}
+
+func wifiStatusFixture() map[string]string {
+	return map[string]string{
+		"interface":     "en0",
+		"rssi":          "-50",
+		"noise":         "-90",
+		"channel":       "6",
+		"channel_width": "20",
+		"channel_band":  "2.4 GHz",
+		"transmit_rate": "300 Mbps",
+		"mode":          "Station",
+	}
 }
 
 // TestWifiNetworkColumns
@@ -66,6 +105,15 @@ func TestGetWifiStatus(t *testing.T) {
 	assert.Equal(t, expected, result)
 }
 
+func TestGetWifiStatusReturnsQueryErrors(t *testing.T) {
+	expectedErr := errors.New("query failed")
+
+	result, err := getWifiStatus(errorOsqueryClient{err: expectedErr})
+
+	require.ErrorIs(t, err, expectedErr)
+	assert.Nil(t, result)
+}
+
 // TestGetValueFromResponse
 func TestGetValueFromResponse(t *testing.T) {
 	tt := []struct {
@@ -96,24 +144,45 @@ func TestGetValueFromResponse(t *testing.T) {
 func TestGetWifiNetworkName(t *testing.T) {
 	tt := []struct {
 		name           string
-		input          string
+		output         []byte
+		err            error
 		expectedResult string
-		expectedError  bool
+		expectedError  string
 	}{
-		{"Wifi network name exists", "en0", "MyNetwork", false},
-		{"Wifi network name does not exist", "en000", "", true},
+		{
+			name:           "Wifi network name exists",
+			output:         []byte("Current Wi-Fi Network: MyNetwork\n"),
+			expectedResult: "MyNetwork",
+		},
+		{
+			name:           "Wifi network is disconnected",
+			output:         []byte("You are not associated with an AirPort network.\n"),
+			expectedResult: "",
+		},
+		{
+			name:          "networksetup fails",
+			err:           errors.New("networksetup failed"),
+			expectedError: "failed to run networksetup",
+		},
 	}
 
 	for _, tc := range tt {
 		t.Run(tc.name, func(t *testing.T) {
-			mockCmdExecutor := MockCommandExecutor{}
-			result, err := getWifiNetworkName(mockCmdExecutor, tc.input)
-			if tc.expectedError {
-				assert.Error(t, err)
+			mockCmdExecutor := &fakeCommandExecutor{
+				responses: map[string][]byte{"/usr/sbin/networksetup": tc.output},
+				errors:    map[string]error{"/usr/sbin/networksetup": tc.err},
+			}
+			result, err := getWifiNetworkName(mockCmdExecutor, "en0")
+			if tc.expectedError != "" {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tc.expectedError)
 			} else {
 				assert.NoError(t, err)
 			}
 			assert.Equal(t, tc.expectedResult, result)
+			require.Len(t, mockCmdExecutor.calls, 1)
+			assert.Equal(t, "/usr/sbin/networksetup", mockCmdExecutor.calls[0].name)
+			assert.Equal(t, []string{"-getairportnetwork", "en0"}, mockCmdExecutor.calls[0].args)
 		})
 	}
 }
@@ -128,17 +197,7 @@ func TestBuildWifiNetworkFromResponse(t *testing.T) {
 	}{
 		{
 			"All keys exist",
-			map[string]string{
-				"interface":     "en0",
-				"rssi":          "-50",
-				"noise":         "-90",
-				"channel":       "6",
-				"channel_width": "20",
-				"channel_band":  "2.4 GHz",
-				"transmit_rate": "300 Mbps",
-				"security_type": "",
-				"mode":          "Station",
-			},
+			wifiStatusFixture(),
 			&WifiNetwork{
 				SSID:         "MyNetwork",
 				Interface:    "en0",
@@ -171,7 +230,7 @@ func TestBuildWifiNetworkFromResponse(t *testing.T) {
 
 	for _, tc := range tt {
 		t.Run(tc.name, func(t *testing.T) {
-			mockCmdExecutor := MockCommandExecutor{}
+			mockCmdExecutor := happyCommandExecutor()
 			result, err := buildWifiNetworkFromResponse(mockCmdExecutor, tc.input)
 			if tc.expectedError {
 				assert.Error(t, err)
@@ -179,6 +238,38 @@ func TestBuildWifiNetworkFromResponse(t *testing.T) {
 				assert.NoError(t, err)
 			}
 			assert.Equal(t, tc.expectedResult, result)
+		})
+	}
+}
+
+func TestBuildWifiNetworkFromResponseReturnsCommandErrors(t *testing.T) {
+	tt := []struct {
+		name          string
+		command       string
+		expectedError string
+	}{
+		{
+			name:          "networksetup error",
+			command:       "/usr/sbin/networksetup",
+			expectedError: "failed to run networksetup",
+		},
+		{
+			name:          "wdutil error",
+			command:       "/usr/bin/wdutil",
+			expectedError: "failed to run wdutil",
+		},
+	}
+
+	for _, tc := range tt {
+		t.Run(tc.name, func(t *testing.T) {
+			mockCmdExecutor := happyCommandExecutor()
+			mockCmdExecutor.errors[tc.command] = errors.New("command failed")
+
+			result, err := buildWifiNetworkFromResponse(mockCmdExecutor, wifiStatusFixture())
+
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), tc.expectedError)
+			assert.Nil(t, result)
 		})
 	}
 }
@@ -230,23 +321,121 @@ func TestBuildWifiNetworkResults(t *testing.T) {
 }
 
 func TestGetWdutilOutput(t *testing.T) {
-	mockCmdExecutor := MockCommandExecutor{}
+	mockCmdExecutor := happyCommandExecutor()
 	result, err := getWdutilOutput(mockCmdExecutor)
 	assert.NoError(t, err)
 	assert.Equal(t, string(wdutilOut), result)
+	require.Len(t, mockCmdExecutor.calls, 1)
+	assert.Equal(t, "/usr/bin/wdutil", mockCmdExecutor.calls[0].name)
+	assert.Equal(t, []string{"info", "-q"}, mockCmdExecutor.calls[0].args)
+}
+
+func TestGetWdutilOutputReturnsCommandErrors(t *testing.T) {
+	mockCmdExecutor := happyCommandExecutor()
+	mockCmdExecutor.errors["/usr/bin/wdutil"] = errors.New("wdutil failed")
+
+	result, err := getWdutilOutput(mockCmdExecutor)
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to run wdutil")
+	assert.Empty(t, result)
 }
 
 func TestExtractSecurityValue(t *testing.T) {
-	expectedOutput := "WPA3 Personal"
+	tt := []struct {
+		name          string
+		input         string
+		interfaceName string
+		expected      string
+	}{
+		{
+			name:          "returns matching interface security",
+			input:         string(wdutilOut),
+			interfaceName: "en0",
+			expected:      "WPA3 Personal",
+		},
+		{
+			name: "returns empty for unmatched interface",
+			input: `Interface Name: en1
+Security: WPA2 Personal`,
+			interfaceName: "en0",
+			expected:      "",
+		},
+		{
+			name: "keeps scanning until requested interface",
+			input: `Interface Name: en1
+Security: WPA2 Personal
+Interface Name: en0
+Security: WPA3 Enterprise`,
+			interfaceName: "en0",
+			expected:      "WPA3 Enterprise",
+		},
+		{
+			name:          "returns empty when security is missing",
+			input:         "Interface Name: en0\nPHY Mode: 11ac",
+			interfaceName: "en0",
+			expected:      "",
+		},
+	}
 
-	output := extractSecurityValue(string(wdutilOut), "en0")
-
-	assert.Equal(t, expectedOutput, output)
+	for _, tc := range tt {
+		t.Run(tc.name, func(t *testing.T) {
+			output := extractSecurityValue(tc.input, tc.interfaceName)
+			assert.Equal(t, tc.expected, output)
+		})
+	}
 }
 
 func TestGetSecurityLevel(t *testing.T) {
-	mockCmdExecutor := MockCommandExecutor{}
+	mockCmdExecutor := happyCommandExecutor()
 	result, err := getSecurityLevel(mockCmdExecutor, "en0")
 	assert.NoError(t, err)
 	assert.Equal(t, "WPA3 Personal", result)
+}
+
+func TestGetSecurityLevelReturnsWdutilErrors(t *testing.T) {
+	mockCmdExecutor := happyCommandExecutor()
+	mockCmdExecutor.errors["/usr/bin/wdutil"] = errors.New("wdutil failed")
+
+	result, err := getSecurityLevel(mockCmdExecutor, "en0")
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to run wdutil")
+	assert.Empty(t, result)
+}
+
+func TestGenerateWithDeps(t *testing.T) {
+	mockOsqueryClient := &utils.MockOsqueryClient{
+		Data: map[string][]map[string]string{
+			"SELECT * FROM wifi_status;": {wifiStatusFixture()},
+		},
+	}
+	mockCmdExecutor := happyCommandExecutor()
+
+	result, err := generateWithDeps(mockOsqueryClient, mockCmdExecutor)
+
+	require.NoError(t, err)
+	assert.Equal(t, []map[string]string{
+		{
+			"ssid":          "MyNetwork",
+			"interface":     "en0",
+			"rssi":          "-50",
+			"noise":         "-90",
+			"channel":       "6",
+			"channel_width": "20",
+			"channel_band":  "2.4 GHz",
+			"transmit_rate": "300 Mbps",
+			"security_type": "WPA3 Personal",
+			"mode":          "Station",
+		},
+	}, result)
+}
+
+func TestGenerateWithDepsReturnsWifiStatusErrors(t *testing.T) {
+	expectedErr := errors.New("query failed")
+
+	result, err := generateWithDeps(errorOsqueryClient{err: expectedErr}, happyCommandExecutor())
+
+	require.ErrorIs(t, err, expectedErr)
+	assert.Nil(t, result)
 }


### PR DESCRIPTION
## Summary
- add deterministic command and osquery fakes for wifi_network tests
- cover disconnected Wi-Fi output, command failures, query errors, generator output, and wdutil parsing edge cases
- route WifiNetworkGenerate through an injectable helper while preserving production behavior

## Tests
- rtk env GOCACHE=/tmp/osquery-extension-go-cache go test ./tables/wifi_network
- rtk env GOCACHE=/tmp/osquery-extension-go-cache go test ./...