### PR TITLE
Fix CI workflow Go setup

### DIFF
--- a/.github/workflows/build_macadmins_extension.yml
+++ b/.github/workflows/build_macadmins_extension.yml
@@ -7,15 +7,15 @@ jobs:
     runs-on: macos-14
 
     steps:
-    - name: Set up Go
-      uses: actions/setup-go@v4
-      with:
-        go-version: '1.21'
-
     - name: Checkout osquery repo repo
-      uses: actions/checkout@24cb9080177205b6e8c946b17badbe402adc938f # v3.4.0
+      uses: actions/checkout@v6
       with:
         fetch-depth: 0
+
+    - name: Set up Go
+      uses: actions/setup-go@v6
+      with:
+        go-version-file: go.mod
     
     - name: Read version from VERSION file
       run: |

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -4,7 +4,7 @@ jobs:
   coverage:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v6
       - uses: actions/setup-go@v6
         with:
           go-version-file: go.mod

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,7 +6,7 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v6
 
       - name: Set up Go
         uses: actions/setup-go@v6
@@ -18,7 +18,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v6
 
       - name: Read version from VERSION file
         run: |


### PR DESCRIPTION
## Summary

Updates CI workflows so they use the repository Go version from `go.mod` and current checkout/setup-go actions.

## Root cause

The manual macOS build workflow still pinned Go 1.21 even though `go.mod` now requires Go 1.25. That is the same class of toolchain drift as the referenced failing lint run, where Actions selected mismatched Go/lint tooling and typechecking failed.

## Changes

- Move the manual macOS build checkout before Go setup so `go-version-file: go.mod` is available.
- Update the manual macOS build workflow to `actions/setup-go@v6` and `actions/checkout@v6`.
- Update test and coverage workflows from `actions/checkout@v3` to `actions/checkout@v6`.

## Validation

- `golangci-lint v2.12.2 run` returned `0 issues`.
- `bazel test --test_output=errors //...` passed 19/19 tests.
- `git diff --check` passed.