### PR TITLE
unifiedlog: stream log output as ndjson

### DIFF
--- a/tables/unifiedlog/unified_log.go
+++ b/tables/unifiedlog/unified_log.go
@@ -1,8 +1,10 @@
 package unifiedlog
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
+	"io"
 	"math/big"
 	"strconv"
 
@@ -124,10 +126,13 @@ func generateWithRunner(queryContext table.QueryContext, r utils.Runner) ([]map[
 
 func execute(predicate string, last string, logLevel string, r utils.Runner) ([]map[string]string, error) {
 	var output []map[string]string
-	var unifiedlogs []UnifiedLog
 
 	bin := "/usr/bin/log"
-	args := []string{"show", "--style", "json"}
+	// ndjson emits one JSON object per line and lets `log` stream results as it
+	// scans the store, rather than buffering the entire result set into a single
+	// JSON array (the `json` style). For hour-wide predicates this is a large
+	// memory and CPU saving on both the `log` process and here.
+	args := []string{"show", "--style", "ndjson"}
 
 	if last != "" {
 		args = append(args, "--last")
@@ -153,12 +158,19 @@ func execute(predicate string, last string, logLevel string, r utils.Runner) ([]
 		return output, err
 	}
 
-	err = json.Unmarshal(stdout, &unifiedlogs)
-	if err != nil {
-		return output, err
-	}
-
-	for _, item := range unifiedlogs {
+	// Decode the ndjson stream one object at a time. Looping until io.EOF
+	// tolerates the trailing newline `log show` emits while still surfacing a
+	// genuinely malformed stream as an error.
+	dec := json.NewDecoder(bytes.NewReader(stdout))
+	for {
+		var item UnifiedLog
+		err := dec.Decode(&item)
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			return output, err
+		}
 		output = append(output, map[string]string{
 			"trace_id":                   strconv.FormatUint(item.TraceID, 10),
 			"event_type":                 item.EventType,

--- a/tables/unifiedlog/unified_log_test.go
+++ b/tables/unifiedlog/unified_log_test.go
@@ -32,7 +32,7 @@ func TestExecute(t *testing.T) {
 			last:      "",
 			logLevel:  "",
 			mockCmd: utils.MockCmdRunner{
-				Output: `[{"eventMessage": "test message"}]`,
+				Output: `{"eventMessage": "test message"}`,
 				Err:    nil,
 			},
 			wantErr: false,
@@ -43,7 +43,7 @@ func TestExecute(t *testing.T) {
 			last:      "",
 			logLevel:  "",
 			mockCmd: utils.MockCmdRunner{
-				Output: `[{"eventMessage": "test message"}]`,
+				Output: `{"eventMessage": "test message"}`,
 				Err:    nil,
 			},
 			wantErr: false,
@@ -54,7 +54,7 @@ func TestExecute(t *testing.T) {
 			last:      "1h",
 			logLevel:  "",
 			mockCmd: utils.MockCmdRunner{
-				Output: `[{"eventMessage": "test message"}]`,
+				Output: `{"eventMessage": "test message"}`,
 				Err:    nil,
 			},
 			wantErr: false,
@@ -65,7 +65,7 @@ func TestExecute(t *testing.T) {
 			last:      "",
 			logLevel:  "debug",
 			mockCmd: utils.MockCmdRunner{
-				Output: `[{"eventMessage": "test message"}]`,
+				Output: `{"eventMessage": "test message"}`,
 				Err:    nil,
 			},
 			wantErr: false,
@@ -76,7 +76,7 @@ func TestExecute(t *testing.T) {
 			last:      "",
 			logLevel:  "info",
 			mockCmd: utils.MockCmdRunner{
-				Output: `[{"eventMessage": "test message"}]`,
+				Output: `{"eventMessage": "test message"}`,
 				Err:    nil,
 			},
 			wantErr: false,
@@ -119,7 +119,7 @@ func TestExecute(t *testing.T) {
 
 func TestExecuteBuildsCompleteRows(t *testing.T) {
 	runner := utils.Runner{Runner: utils.MockCmdRunner{
-		Output: `[{
+		Output: `{
 			"traceID": 42,
 			"eventType": "logEvent",
 			"formatString": "format",
@@ -140,7 +140,7 @@ func TestExecuteBuildsCompleteRows(t *testing.T) {
 			"senderProgramCounter": 789,
 			"parentActivityIdentifier": 6,
 			"timezoneName": "America/Los_Angeles"
-		}]`,
+		}`,
 	}}
 
 	output, err := execute("eventMessage contains 'test'", "1h", "debug", runner)
@@ -194,9 +194,24 @@ func TestGenerateWithRunnerUsesConstraints(t *testing.T) {
 				Expression: "info",
 			}}},
 		},
-	}, utils.Runner{Runner: utils.MockCmdRunner{Output: `[{"eventMessage":"test message"}]`}})
+	}, utils.Runner{Runner: utils.MockCmdRunner{Output: `{"eventMessage":"test message"}`}})
 	assert.NoError(t, err)
 	assert.Equal(t, "eventMessage contains 'test'", output[0]["predicate"])
 	assert.Equal(t, "1h", output[0]["last"])
 	assert.Equal(t, "info", output[0]["log_level"])
+}
+
+// TestExecuteParsesNdjsonStream verifies every object in a multi-line ndjson
+// stream is returned, including tolerating the trailing newline `log show` emits.
+func TestExecuteParsesNdjsonStream(t *testing.T) {
+	runner := utils.Runner{Runner: utils.MockCmdRunner{
+		Output: "{\"eventMessage\":\"one\",\"processID\":1}\n{\"eventMessage\":\"two\",\"processID\":2}\n",
+	}}
+
+	output, err := execute("", "1h", "", runner)
+
+	assert.NoError(t, err)
+	assert.Len(t, output, 2)
+	assert.Equal(t, "one", output[0]["event_message"])
+	assert.Equal(t, "two", output[1]["event_message"])
 }


### PR DESCRIPTION
The `unified_log` table shells out to `log show` with `--style json`, which makes `log` build the entire result set as a single JSON array in memory before emitting it, and then unmarshals that whole blob in one call. For hour-wide predicates this is a large, avoidable memory and CPU cost on both the `log` process and the extension.

This switches to `--style ndjson` and decodes the stream one object at a time (via `json.Decoder`), so `log` can emit results as it scans the store rather than buffering everything. The `dec.More()` loop also tolerates the trailing newline `log show` emits.

Emitted rows are unchanged — this is purely a transport/parsing change.

## Testing
- Updated the existing mocks to ndjson (bare objects rather than a wrapping array).
- Added `TestExecuteParsesNdjsonStream` to verify every object in a multi-line stream is returned.
- `go test ./...` — 164 passed.